### PR TITLE
Add 'evidence.sqltools-duckdb-driver' extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -328,6 +328,9 @@
   "evaera.vscode-rojo": {
     "repository": "https://github.com/rojo-rbx/vscode-rojo"
   },
+  "evidence.sqltools-duckdb-driver": {
+    "repository": "https://github.com/evidence-dev/sqltools-duckdb-driver"
+  },
   "exiasr.hadolint": {
     "repository": "https://github.com/ExiaSR/vscode-hadolint"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] The author gave permission for their extension to be published on Open VSX [here](<https://github.com/evidence-dev/sqltools-duckdb-driver/issues/20#issuecomment-2338605934>).
-   [x] As of the time of opening this pull request the extension has an [MIT license](<https://github.com/evidence-dev/sqltools-duckdb-driver/blob/master/LICENSE.md>) ([permalink](<https://github.com/evidence-dev/sqltools-duckdb-driver/blob/4f65f8b8679e5c816a34de1bfda41e913728fa26/LICENSE.md>))

## Description

This PR adds the `DuckDB Driver for SQLTools` extension ([link](<https://github.com/evidence-dev/sqltools-duckdb-driver>)).
