### PR TITLE
feat(extensions.json): Boundary.baml-extension-preview should redirect to Boundary.baml-extension

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -376,6 +376,13 @@
                 "id": "redhat.apache-camel-extension-pack",
                 "displayName": "Extension Pack for Apache Camel by Red Hat"
             }
+        },
+        "Boundary.baml-extension-preview": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "Boundary.baml-extension",
+                "displayName": "BAML"
+            }
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
Per [docs](https://github.com/EclipseFdn/open-vsx.org/wiki/Managing-Extensions#deprecating-an-extension), I'm requesting a deprecation of https://open-vsx.org/extension/Boundary/baml-extension-preview.

[Boundary.baml-extension-preview](https://open-vsx.org/extension/Boundary/baml-extension-preview) was published while doing some internal alpha testing of our open vsx release process, but because I chose such a similar name to our actual extension, [Boundary.baml-extension](https://open-vsx.org/extension/Boundary/baml-extension), it looks like some of our users have landed on baml-extension-preview instead of baml-extension.

Deprecation seems like the correct way to handle this; please let me know if there's a more appropriate way to do so.