### PR TITLE
Fix TailwindCSS Intellisense extension

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -33,12 +33,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.1.0
         with:
-          node-version: "18.x"
+          node-version: "20.x"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Set up pyenv
-        uses: "gabrielfalcao/pyenv-action@2f49ca7587f9d0663d13f1147b78d3361417eaf7"
+        uses: "gabrielfalcao/pyenv-action@32ef4d2c861170ce17ded56d10329d83f4c8f797"
         with:
             command: python --version
       - name: Set default global version
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libpango1.0-dev libgif-dev
       - run: npm install
-      - run: npm i -g @vscode/vsce
+      - run: npm i -g @vscode/vsce pnpm
       - run: node publish-extensions
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           bun-version: latest
       - run: npm install
-      - run: npm i -g @vscode/vsce
+      - run: npm i -g @vscode/vsce pnpm
       - name: Set up pyenv
-        uses: "gabrielfalcao/pyenv-action@2f49ca7587f9d0663d13f1147b78d3361417eaf7"
+        uses: "gabrielfalcao/pyenv-action@32ef4d2c861170ce17ded56d10329d83f4c8f797"
         with:
             command: python --version
       - name: Set default global version

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
   - init: |
-      npm i -g @vscode/vsce
+      npm i -g @vscode/vsce pnpm
       curl -fsSL https://bun.sh/install | bash
       npm i

--- a/extensions.json
+++ b/extensions.json
@@ -137,7 +137,12 @@
     "repository": "https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight"
   },
   "bradlc.vscode-tailwindcss": {
-    "repository": "https://github.com/tailwindlabs/tailwindcss-intellisense"
+    "repository": "https://github.com/tailwindlabs/tailwindcss-intellisense",
+    "location": "packages/vscode-tailwindcss",
+    "custom": [
+      "npx -y pnpm install",
+      "cd packages/vscode-tailwindcss && npx -y vsce package --no-dependencies -o extension.vsix"
+    ]
   },
   "BriteSnow.vscode-toggle-quotes": {
     "repository": "https://github.com/BriteSnow/vscode-toggle-quotes"

--- a/extensions.json
+++ b/extensions.json
@@ -141,7 +141,7 @@
     "location": "packages/vscode-tailwindcss",
     "custom": [
       "npx -y pnpm install",
-      "cd packages/vscode-tailwindcss && npx -y vsce package --no-dependencies -o extension.vsix"
+      "cd packages/vscode-tailwindcss && vsce package --no-dependencies -o extension.vsix"
     ]
   },
   "BriteSnow.vscode-toggle-quotes": {


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
    - Not my issue, but see https://github.com/tailwindlabs/tailwindcss-intellisense/issues/219#issuecomment-1014701806
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR updates the [TailwindCSS Intellisense](https://open-vsx.org/extension/bradlc/vscode-tailwindcss) ([GitHub repo](https://github.com/tailwindlabs/tailwindcss-intellisense)) extension entry in `extensions.json` to fix automated publishing to Open VSX.

Automated publishing stopped working after version 0.10.2, so I suspect the problem was initially caused by [this commit](https://github.com/tailwindlabs/tailwindcss-intellisense/commit/19cb859b5d92897c16cdd271786ca07d8d06d011).

This includes two changes:
1. I changed the extension package's root directory to [`packages/vscode-tailwindcss`](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/main/packages/vscode-tailwindcss). This is where the source for the VS Code extension lives.
2. I switched from `npm` to `pnpm`. This is required because, as of [this commit](https://github.com/tailwindlabs/tailwindcss-intellisense/commit/82f152d3f213de28d24a951ce598d974eb51cf29), the repository relies on the `pnpm`-specific [workspace](https://pnpm.io/workspaces) feature.

This works on my machine when testing with this command:
```sh
EXTENSIONS=bradlc.vscode-tailwindcss node publish-extensions.js
```
This generates an artifact at `/tmp/artifacts/bradlc.vscode-tailwindcss.vsix`, which I was able to install and use in VSCodium. 

I looked at the GitHub Actions workflow file, and I couldn't see a step that installed `pnpm`, so I'm using it here via `npx`. The `-y` option disables prompting the user before automatically installing the package if it isn't found locally.