### PR TITLE
Add GitSmart extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1579,5 +1579,8 @@
   },
   "zxh404.vscode-proto3": {
     "repository": "https://github.com/zxh0/vscode-proto3"
+  },
+  "arielpollack.gitsmart": {
+    "repository": "https://github.com/arielpollack/vscode-gitsmart"
   }
 }


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR introduces GitSmart extension.
I'm the author and currently it's easier for me to auto-publish this extension rather than publishing to both marketplaces.
When I'll set up continuous deployment in my repo I'll remove if from auto publish.
