### PR TITLE
Update extensions.json

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -297,7 +297,7 @@
         },
         "iocave.customize-ui": true,
         "iocave.monkey-patch": true,
-        "pranaygp.vscode-css-peek": true,
+        "pranaygp.vscode-css-peek": false,
         "redhat.vscode-wsdl2rest": true,
         "ms-vscode.node-debug2": true,
         "ms-vscode.node-debug": true,

--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -297,7 +297,6 @@
         },
         "iocave.customize-ui": true,
         "iocave.monkey-patch": true,
-        "pranaygp.vscode-css-peek": false,
         "redhat.vscode-wsdl2rest": true,
         "ms-vscode.node-debug2": true,
         "ms-vscode.node-debug": true,


### PR DESCRIPTION
cancel deprecation of CSS Peek extension:
https://github.com/EclipseFdn/open-vsx.org/issues/3540

-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

<!-- Please do not leave this blank -->

This PR introduces X change for Y reason.
