### PR TITLE
deprecate 2 extensions

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -420,6 +420,20 @@
                 "id": "neo4j-extensions.neo4j-for-vscode",
                 "displayName": "Neo4j for VS Code"
             }
+        },
+        "KylinIdeTeam.debug": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "KylinIdeTeam.kylin-debug",
+                "displayName": "Kylin Debug"
+            }
+        },
+        "KylinIdeTeam.vscode-clangd": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "KylinIdeTeam.kylin-clangd",
+                "displayName": "Kylin Clangd"
+            }
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
## Description

<!-- Please do not leave this blank -->

This PR introduces 2 changes

1. Change extension id `KylinIdeTeam.debug` to `KylinIdeTeam.kylin-debug`
2. Change extension id `KylinIdeTeam.vscode-clangd` to `KylinIdeTeam.kylin-clangd`
