### PR TITLE
Update extensions.json - deprecate Azure Repos extension

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -434,6 +434,13 @@
                 "id": "KylinIdeTeam.kylin-clangd",
                 "displayName": "Kylin Clangd"
             }
+        },
+        "ms-vsts.team": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "ms-vsts.team",
+                "displayName": "Azure Repos"
+            }
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
## Description

This PR introduces deprecation of https://open-vsx.org/extension/ms-vsts/team ("Azure Repos extension") extension to fix https://github.com/EclipseFdn/open-vsx.org/issues/3635

