### PR TITLE
Add The Qt Company's family of Qt extensions

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           distribution: "microsoft"
           java-version: "17"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
       - name: Install dependencies for native modules
         run: |
           sudo apt-get update

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -30,6 +30,9 @@ jobs:
         run: |
           pyenv install 3.8
           pyenv global 3.8
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
       - run: EXTENSIONS=$(node diff-extensions) node publish-extensions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/extensions.json
+++ b/extensions.json
@@ -1375,6 +1375,53 @@
   "tecosaur.latex-utilities": {
     "repository": "https://github.com/tecosaur/LaTeX-Utilities"
   },
+  "theqtcompany.qt": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "extension_packs/qt/"
+  },
+  "theqtcompany.qt-cpp": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "qt-cpp/",
+    "prepublish": "npm run ci:qt-lib && npm run compile:qt-lib && npm run compile:qt-cpp"
+  },
+  "theqtcompany.qt-cpp-pack": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "extension_packs/cpp/"
+  },
+  "theqtcompany.qt-core": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "qt-core/",
+    "custom": [
+      "npm ci",
+      "npm run ci:qt-lib",
+      "npm run ci:qt-core",
+
+      "npm run compile:qt-lib",
+
+      "go install github.com/goreleaser/goreleaser/v2@latest",
+      "cd qt-cli && GORELEASER_CURRENT_TAG=${VERSION} goreleaser release --snapshot --clean",
+      "mkdir -p qt-core/res/qtcli",
+      "if [ -e qt-cli/dist/bin ]; then cp -r qt-cli/dist/bin/* qt-core/res/qtcli; else cp qt-cli/dist/qtcli_{linux,windows,darwin_fat}* qt-core/res/qtcli; fi",
+
+      "npm run package:qt-core",
+      "mv qt-core/out/qt-core-*.vsix qt-core/out/qt-core.vsix"
+    ],
+    "extensionFile": "out/qt-core.vsix"
+  },
+  "theqtcompany.qt-qml": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "qt-qml/",
+    "prepublish": "npm run ci:qt-lib && npm run compile:qt-lib && npm run compile:qt-qml"
+  },
+  "theqtcompany.qt-ui": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "qt-ui/",
+    "prepublish": "npm run ci:qt-lib && npm run compile:qt-lib && npm run compile:qt-ui"
+  },
+  "theqtcompany.qt-wasm-pack": {
+    "repository": "https://github.com/qt-labs/vscodeext",
+    "location": "extension_packs/wasm/"
+  },
   "Tobiah.unity-tools": {
     "repository": "https://github.com/TobiahZ/unity-tools"
   },


### PR DESCRIPTION
<!--

### For extension authors

`publish-extensions` exists to seed the Open VSX marketplace, and also serves as a place for extensions that cannot feasibly be published directly by the extensions authors. In the long-run it is better for extension owners to publish their own plugins because:

1. Any future issues (features/bugs) with any published extensions in Open VSX will be directed to their original repo/source-control, and not confused with this repo publish-extensions.
2. Extensions published by official authors are shown within the Open VSX marketplace as such. Whereas extensions published via publish-extensions display a warning that the publisher (this repository) is not the official author.
3. Extension owners who publish their own extensions get greater flexibility on the publishing/release process, therefore ensure more accuracy/stability. For instance, in some cases publish-extensions has build steps within this repository, which can cause some uploaded plugin versions to break (e.g. if a plugin build step changes).

If you are the author of the extension being raised in this PR, please first consider directly publishing the extension yourself. You can refer to our [direct publish setup](docs/direct_publish_setup.md) doc for a guide on how to publish your plugin to Open VSX.

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to Open VSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

<!-- Please do not leave this blank -->

This add The Qt Company's family of Qt extensions. PR These extensions all live in a single repository. Most extensions are relatively straight-forward to build (non-extension-pack ones require building common library first). However, qt-core comes with a binary written in Go, which requires us to use custom commands to facilitate building it using GoReleaser.

Build commands have handling for difference between the currently- published version and the current Git tip, in anticipation that the Git tip will eventually be released.

GitHub workflows are modified to ensure Go environment is available.

Extensions are dual-licensed between Qt's commercial license and LGPL 3.0 only. The issue which request publishing on Open-VSX [1] gets some interest from upstream, but does not have any update since September 2024.

[1]\: https://bugreports.qt.io/browse/VSCODEEXT-96