### PR TITLE
Update JDK version from 17 to 21 for extension publishing.

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: "microsoft"
-          java-version: "17"
+          java-version: "21"
       - name: Install dependencies for native modules
         run: |
           sudo apt-get update


### PR DESCRIPTION
- Fixes https://github.com/EclipseFdn/publish-extensions/issues/851, specifically https://github.com/EclipseFdn/publish-extensions/issues/851#issuecomment-2785957263 .
- When rebuilding an extension, that has a language server (that must also rebuild), if the language server relies on the latest Eclipse Platform, it will have the same BREE minimum
- Eclipse 4.35 (2025-03) requires a JRE 21

See https://eclipse.dev/eclipse/development/readme_eclipse_4.35.html#mozTocId693657
> As shown [above](https://eclipse.dev/eclipse/development/readme_eclipse_4.35.html#TargetOperatingEnvironments), Eclipse 4.35 requires at least a Java SE 21.