### PR TITLE
add gerane's SunBurst theme

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -388,6 +388,15 @@
   "geequlim.godot-tools": {
     "repository": "https://github.com/godotengine/godot-vscode-plugin"
   },
+  "gerane.Theme-Sunburst": {
+    "repository": "https://github.com/gerane/VSCodeThemes",
+    "location": "gerane.Theme-Sunburst",
+    "custom": [
+      "cd gerane.Theme-Sunburst",
+      "vsce package -o Theme-Sunburst-0.0.1.vsix"
+    ],
+    "extensionFile": "Theme-Sunburst-0.0.1.vsix"
+  },
   "gharveymn.nightswitch-lite": {
     "repository": "https://github.com/gharveymn/nightswitch-lite"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This adds the Sunburst theme from gerane's VSCodeThemes repo, which appears to be abandoned; no changes have been made in six years and the issue [asking to have them added to Open VSX](https://github.com/gerane/VSCodeThemes/issues/98) has been ignored for a bit over two years. The theme itself hasn't been touched in 10 years.

No license is specified in the repo, or on the theme, but it's one of many ports of TextMate's Sunburst theme to a wide variety of editors.