### PR TITLE
Deprecate Gydunhn Angular Essentials Editions extensions Packs

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -28,6 +28,36 @@
         }
     ],
     "deprecated": {
+        "Gydunhn.angular-essentials-barracks": {
+            "disallowInstall": true,
+            "additionalInfo": "Please use the Angular-Essentials (https://open-vsx.org/extension/Gydunhn/angular-essentials) extension instead.",
+            "extension": {
+                "id": "Gydunhn.angular-essentials-barracks",
+                "displayName": "Angular-Essentials-Barracks-Edition",
+                "deprecated": true,
+                "replacement": "Gydunhn.angular-essentials"
+            }
+        },
+        "Gydunhn.angular-essentials-tbk": {
+            "disallowInstall": true,
+            "additionalInfo": "Please use the Angular-Essentials (https://open-vsx.org/extension/Gydunhn/angular-essentials) extension instead.",
+            "extension": {
+                "id": "Gydunhn.angular-essentials-tbk",
+                "displayName": "Angular-Essentials-TBK-Edition",
+                "deprecated": true,
+                "replacement": "Gydunhn.angular-essentials"
+            }
+        },
+        "Gydunhn.angular-essentials-plv": {
+            "disallowInstall": true,
+            "additionalInfo": "Please use the Angular-Essentials (https://open-vsx.org/extension/Gydunhn/angular-essentials) extension instead.",
+            "extension": {
+                "id": "Gydunhn.angular-essentials-plv",
+                "displayName": "Angular-Essentials-PLV-Edition",
+                "deprecated": true,
+                "replacement": "Gydunhn.angular-essentials"
+            }
+        },
         "andrewhertog.codex-editor-extension": true,
         "decodetalkers.neocmake-lsp-vscode": {
             "disallowInstall": false,


### PR DESCRIPTION
## Description
This PR requests to deprecate the following extensions:
* Gydunhn.angular-essentials-barracks
* Gydunhn.angular-essentials-tbk
* Gydunhn.angular-essentials-plv

## Justification
I am the author/maintainer of these extensions and can no longer actively maintain them, i will only support this one :  Gydunhn.angular-essentials

- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I am the maintainer/author of these extensions (no need to contact the maintainer)
- [x] These extensions have an OSI-approved OSS license