### PR TITLE
Add 498.pythonformat to malicious extensions

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -3,7 +3,8 @@
         "kyntrack.log-matrix",
         "bipro.bipro-dev",
         "Equinusocio.vsc-material-theme",
-        "Equinusocio.vsc-material-theme-icons"
+        "Equinusocio.vsc-material-theme-icons",
+        "498.pythonformat"
     ],
     "search": [
         {


### PR DESCRIPTION
Related issue: https://github.com/EclipseFdn/open-vsx.org/issues/3967