### PR TITLE
Use separate jobs instead of child_process

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -93,8 +93,13 @@ jobs:
           PUBLISH_CONTEXT: ${{inputs.publishContext}}
         with:
           script: |
-            const script = require('./scripts/build-extension.js');
-            await script({core});
+            const extension = JSON.parse(process.env.EXTENSION);
+            const publishContext = JSON.parse(process.env.PUBLISH_CONTEXT);
+            const buildScript = require('./scripts/build-extension.js');
+            const extensionFiles = await buildScript(extension, publishContext);
+            const uploadScript = require('./scripts/upload-artifacts.js');
+            const extensionFiles = await uploadScript(extensionFiles);
+            core.setOutput("extensionFiles", JSON.stringify(extensionFiles));
     outputs:
       extensionFiles: ${{ steps.build_extension.outputs.extensionFiles }}
   publish_extension:
@@ -121,5 +126,7 @@ jobs:
           EXTENSION_FILES: ${{needs.build_extension.outputs.extensionFiles}}
         with:
           script: |
+            const extensionId = process.env.EXTENSION_ID;
+            const extensionFiles = JSON.parse(process.env.EXTENSION_FILES);
             const script = require('./scripts/publish-extension.js');
-            await script();
+            await script(extensionId, extensionFiles);

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,125 @@
+name: Publish extension
+on:
+  workflow_dispatch:
+    inputs:
+      extension:
+        description: Extension JSON object
+        required: true
+        type: string
+      publishContext:
+        description: Publish context JSON object
+        required: true
+        type: string
+      skipPublish:
+        description: Skip publishing to Open VSX, only build extensions
+        required: true
+        type: boolean
+      force:
+        description: Force publish to Open VSX, even if version is already published
+        required: true
+        type: boolean
+jobs:
+  download_release:
+    name: Download latest release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DO_DOWNLOAD: ${{ fromJSON(inputs.publishContext).files != null }}
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ env.DO_DOWNLOAD == 'true' }}
+      - uses: actions/setup-node@v4.3.0
+        if: ${{ env.DO_DOWNLOAD == 'true' }}
+        with:
+          node-version: "20.x"
+      - run: npm install
+        if: ${{ env.DO_DOWNLOAD == 'true' }}
+      - run: npm i -g @vscode/vsce pnpm
+        if: ${{ env.DO_DOWNLOAD == 'true' }}
+      - id: download_extension
+        uses: actions/github-script@v7
+        if: ${{ env.DO_DOWNLOAD == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXTENSION: ${{ inputs.extension }}
+          PUBLISH_CONTEXT: ${{ inputs.publishContext }}
+        with:
+          script: |
+            const script = require('./scripts/download-extension.js');
+            await script();
+  build_extension:
+    name: Build Extension
+    runs-on: ubuntu-latest
+    needs: download_release
+    permissions:
+      actions: none
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.3.0
+        with:
+          node-version: "20.x"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Set up pyenv
+        uses: "gabrielfalcao/pyenv-action@32ef4d2c861170ce17ded56d10329d83f4c8f797"
+        with:
+            command: python --version
+      - name: Set default global version
+        run: |
+          pyenv install 3.8
+          pyenv global 3.8
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "microsoft"
+          java-version: "21"
+      - name: Install dependencies for native modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpango1.0-dev libgif-dev
+      - run: npm install
+      - run: npm i -g @vscode/vsce pnpm
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp
+      - id: build_extension
+        name: Build extension
+        uses: actions/github-script@v7
+        env:
+          FORCE: ${{ inputs.force }}
+          SKIP_PUBLISH: ${{ inputs.skipPublish }}
+          EXTENSION: ${{ inputs.extension }}
+          PUBLISH_CONTEXT: ${{inputs.publishContext}}
+        with:
+          script: |
+            const script = require('./scripts/build-extension.js');
+            await script({core});
+    outputs:
+      extensionFiles: ${{ steps.build_extension.outputs.extensionFiles }}
+  publish_extension:
+    name: Publish Extension
+    runs-on: ubuntu-latest
+    if: ${{ inputs.skipPublish != 'true' }}
+    needs: build_extension
+    permissions:
+      actions: none
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.3.0
+        with:
+          node-version: "20.x"
+      - run: npm install
+      - run: npm i -g @vscode/vsce pnpm
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp
+      - uses: actions/github-script@v7
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          EXTENSION_ID: ${{ fromJson(inputs.extension).id }}
+          EXTENSION_FILES: ${{needs.build_extension.outputs.extensionFiles}}
+        with:
+          script: |
+            const script = require('./scripts/publish-extension.js');
+            await script();

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -98,7 +98,7 @@ jobs:
             const buildScript = require('./scripts/build-extension.js');
             const extensionFiles = await buildScript(extension, publishContext);
             const uploadScript = require('./scripts/upload-artifacts.js');
-            const extensionFiles = await uploadScript(extensionFiles);
+            await uploadScript(extensionFiles);
             core.setOutput("extensionFiles", JSON.stringify(extensionFiles));
     outputs:
       extensionFiles: ${{ steps.build_extension.outputs.extensionFiles }}

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -46,7 +46,24 @@ jobs:
         with:
           script: |
             const script = require('./scripts/publish-extensions.js');
-            await script({github});
+            await script(async (extension, context) => {
+              const [owner, repo] = process.env.REPOSITORY.split("/");
+              await github.request("POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches", {
+                  owner,
+                  repo,
+                  workflow_id: "publish-extension.yml",
+                  ref: "build-extension",
+                  inputs: {
+                      extension: JSON.stringify(extension),
+                      publishContext: JSON.stringify(context),
+                      force: process.env.FORCE,
+                      skipPublish: process.env.SKIP_PUBLISH,
+                  },
+                  headers: {
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              });
+            });
       # TODO fix reporting
       # - name: Report results
       #   run: bun run ./report-extensions.ts

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -29,67 +29,58 @@ jobs:
       FORCE: ${{ github.event.inputs.forcefullyPublish }}
     name: Publish Extensions
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.3.0
         with:
           node-version: "20.x"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - name: Set up pyenv
-        uses: "gabrielfalcao/pyenv-action@32ef4d2c861170ce17ded56d10329d83f4c8f797"
-        with:
-            command: python --version
-      - name: Set default global version
-        run: |
-          pyenv install 3.8
-          pyenv global 3.8
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "microsoft"
-          java-version: "21"
-      - name: Install dependencies for native modules
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
       - run: npm install
       - run: npm i -g @vscode/vsce pnpm
-      - run: node publish-extensions
+      - uses: actions/github-script@v7
         env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Report results
-        run: bun run ./report-extensions.ts
-      - uses: actions/upload-artifact@v4
-        if: always()
+          REPOSITORY: ${{ github.repository }}
         with:
-          name: report
-          path: |
-            /tmp/stat.json
-            /tmp/result.md
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: artifacts
-          path: |
-            /tmp/artifacts/*.vsix
-      - name: Upload job summary
-        if: always()
-        run: cat /tmp/result.md >> $GITHUB_STEP_SUMMARY
-      - name: Get previous job's status
-        id: lastrun
-        uses: filiptronicek/get-last-job-status@main
-      - name: Slack Notification
-        if: ${{ !github.event.inputs.extensions && ((success() && steps.lastrun.outputs.status == 'failed') || failure()) }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.GITPOD_SLACK_WEBHOOK }}
-          SLACK_COLOR: ${{ job.status }}
+          script: |
+            const script = require('./scripts/publish-extensions.js');
+            await script({github});
+      # TODO fix reporting
+      # - name: Report results
+      #   run: bun run ./report-extensions.ts
+      # - uses: actions/upload-artifact@v4
+      #   if: always()
+      #   with:
+      #     name: report
+      #     path: |
+      #       /tmp/stat.json
+      #       /tmp/result.md
+      # - uses: actions/upload-artifact@v4
+      #   if: always()
+      #   with:
+      #     name: artifacts
+      #     path: |
+      #       /tmp/artifacts/*.vsix
+      # - name: Upload job summary
+      #   if: always()
+      #   run: cat /tmp/result.md >> $GITHUB_STEP_SUMMARY
+      # - name: Get previous job's status
+      #   id: lastrun
+      #   uses: filiptronicek/get-last-job-status@main
+      # - name: Slack Notification
+      #   if: ${{ !github.event.inputs.extensions && ((success() && steps.lastrun.outputs.status == 'failed') || failure()) }}
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_WEBHOOK: ${{ secrets.GITPOD_SLACK_WEBHOOK }}
+      #     SLACK_COLOR: ${{ job.status }}
   check_parity:
     name: Check MS parity
     runs-on: ubuntu-latest
     needs: publish_extensions
+    permissions:
+      actions: none
     if: ${{ !github.event.inputs.extensions }} # only run on full runs
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -30,9 +30,15 @@ jobs:
         run: |
           pyenv install 3.8
           pyenv global 3.8
-      - run: EXTENSIONS=$(node diff-extensions) node publish-extensions
+      - run: echo "EXTENSIONS=$(node diff-extensions)" >> $GITHUB_ENV
+      - uses: actions/github-script@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        with:
+          script: |
+            const script = require('./scripts/publish-extensions.js');
+            await script({github});
       - name: Report results
         run: bun run ./report-extensions.ts
       - uses: actions/upload-artifact@v4

--- a/local-workflow.js
+++ b/local-workflow.js
@@ -13,7 +13,12 @@ const publishExtensionsScript = require("./scripts/publish-extensions");
 const buildExtensionScript = require("./scripts/build-extension");
 const publishExtensionScript = require("./scripts/publish-extension");
 
-await publishExtensionsScript(async (extension, publishContext) => {
-    const extensionFiles = await buildExtensionScript(extension, publishContext);
-    await publishExtensionScript(extension.id, extensionFiles);
-})
+(async () => {
+    process.env.EXTENSIONS = "dfinity-foundation.vscode-motoko";
+    process.env.SKIP_PUBLISH = "false";
+    process.env.FORCE = "true";
+    await publishExtensionsScript(async (extension, publishContext) => {
+        const extensionFiles = await buildExtensionScript(extension, publishContext);
+        await publishExtensionScript(extension.id, extensionFiles);
+    });
+})();

--- a/local-workflow.js
+++ b/local-workflow.js
@@ -14,9 +14,9 @@ const buildExtensionScript = require("./scripts/build-extension");
 const publishExtensionScript = require("./scripts/publish-extension");
 
 (async () => {
-    process.env.EXTENSIONS = "dfinity-foundation.vscode-motoko";
-    process.env.SKIP_PUBLISH = "false";
-    process.env.FORCE = "true";
+    process.env.SKIP_PUBLISH ??= "true";
+    process.env.FORCE ??= "true";
+
     await publishExtensionsScript(async (extension, publishContext) => {
         const extensionFiles = await buildExtensionScript(extension, publishContext);
         await publishExtensionScript(extension.id, extensionFiles);

--- a/local-workflow.js
+++ b/local-workflow.js
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2025 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+// @ts-check
+const publishExtensionsScript = require("./scripts/publish-extensions");
+const buildExtensionScript = require("./scripts/build-extension");
+const publishExtensionScript = require("./scripts/publish-extension");
+
+await publishExtensionsScript(async (extension, publishContext) => {
+    const extensionFiles = await buildExtensionScript(extension, publishContext);
+    await publishExtensionScript(extension.id, extensionFiles);
+})

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "find-up": "^5.0.0",
     "human-number": "^2.0.0",
     "jest-diff": "^29.7.0",
+    "limiter": "^3.0.0",
     "minimist": "^1.2.5",
     "octokit": "^3.1.2",
     "ovsx": "latest",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@actions/artifact": "^2.3.2",
     "@vscode/vsce": "^3.0.0",
     "ajv": "^8.8.1",
     "chai": "^5.1.0",
@@ -41,12 +42,17 @@
     "octokit": "^3.1.2",
     "ovsx": "latest",
     "prettier": "^3.2.5",
-    "semver": "^7.1.3"
+    "semver": "^7.1.3",
+    "xml2js": "^0.6.2",
+    "yauzl-promise": "^4.0.0"
   },
   "devDependencies": {
+    "@actions/github-script": "github:actions/github-script",
     "@types/human-number": "^1.0.0",
     "@types/node": "^22.2.0",
     "@types/unzipper": "^0.10.5",
+    "@types/xml2js": "^0.4.14",
+    "@types/yauzl-promise": "^4.0.1",
     "bun-types": "^1.0.1"
   }
 }

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -18,7 +18,6 @@ const findUp = require("find-up");
 const fg = require("fast-glob");
 
 const { createVSIX } = require("@vscode/vsce");
-const { DefaultArtifactClient } = require("@actions/artifact");
 const { cannotPublish } = require("../lib/reportStat");
 
 const { PublicGalleryAPI } = require("@vscode/vsce/out/publicgalleryapi");
@@ -298,10 +297,11 @@ async function buildVersion(extension, publishContext) {
 }
 
 // @ts-check
-/** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ core }) => {
-    const extension = JSON.parse(process.env.EXTENSION);
-    const publishContext = JSON.parse(process.env.PUBLISH_CONTEXT);
+/**
+ * @param {import('../types').Extension} extension
+ * @param {import('../types').PublishContext} publishContext
+ */
+module.exports = async (extension, publishContext) => {
     publishContext.msLastUpdated = new Date(publishContext.msLastUpdated);
     publishContext.ovsxLastUpdated = new Date(publishContext.ovsxLastUpdated);
 
@@ -347,10 +347,5 @@ module.exports = async ({ core }) => {
         }
     }
 
-    const artifact = new DefaultArtifactClient();
-    await artifact.uploadArtifact("artifacts", extensionFiles, artifactDirectory, {
-        retentionDays: 7,
-    });
-
-    core.setOutput("extensionFiles", JSON.stringify(extensionFiles));
+    return extensionFiles;
 };

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -74,6 +74,7 @@ async function buildVersion(extension, publishContext) {
             options = { extensionFile: publishContext.file, targets: [publishContext.target] };
         } else if (publishContext.repo && publishContext.ref) {
             console.log(`${id}: preparing from ${publishContext.repo}...`);
+            await exec("rm -rf /tmp/repository /tmp/download", { quiet: true });
             await resolveExtension(
                 extension,
                 publishContext.msVersion && {

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -7,23 +7,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
-
 // @ts-check
 const fs = require("fs");
 const ovsx = require("ovsx");
 const readVSIXPackage = require("@vscode/vsce/out/zip").readVSIXPackage;
 const path = require("path");
 const semver = require("semver");
-const exec = require("./lib/exec");
+const exec = require("../lib/exec");
 const findUp = require("find-up");
 const fg = require("fast-glob");
 
 const { createVSIX } = require("@vscode/vsce");
-const { cannotPublish } = require("./lib/reportStat");
+const {DefaultArtifactClient} = require('@actions/artifact')
+const { cannotPublish } = require("../lib/reportStat");
 
 const { PublicGalleryAPI } = require("@vscode/vsce/out/publicgalleryapi");
 const { PublishedExtension } = require("azure-devops-node-api/interfaces/GalleryInterfaces");
-const { artifactDirectory, registryHost, defaultPythonVersion } = require("./lib/constants");
+const { artifactDirectory, registryHost, defaultPythonVersion } = require("../lib/constants");
+const resolveExtension = require("../lib/resolveExtension").resolveExtension;
 
 const vscodeBuiltinExtensionsNamespace = "vscode";
 const isBuiltIn = (id) => id.split(".")[0] === vscodeBuiltinExtensionsNamespace;
@@ -34,43 +35,69 @@ openGalleryApi.client["_maxRetries"] = 5;
 openGalleryApi.post = (url, data, additionalHeaders) =>
     openGalleryApi.client.post(`${openGalleryApi.baseUrl}${url}`, data, additionalHeaders);
 
-(async () => {
-    /**
-     * @type {{extension: import('./types').Extension, context: import('./types').PublishContext, extensions: Readonly<import('./types').Extensions>}}
-     */
-    const { extension, context, extensions } = JSON.parse(process.argv[2]);
-    console.log(`\nProcessing extension: ${JSON.stringify({ extension, context }, undefined, 2)}`);
-    try {
-        const { id } = extension;
-        const [namespace] = id.split(".");
+const ensureBuildPrerequisites = async () => {
+    // Make yarn use bash
+    await exec("yarn config set script-shell /bin/bash");
 
-        let packagePath = context.repo;
+    // Don't show large git advice blocks
+    await exec("git config --global advice.detachedHead false");
+
+    // Create directory for storing built extensions
+    if (fs.existsSync(artifactDirectory)) {
+        // If the folder has any files, delete them
+        try {
+            fs.rmSync(`${artifactDirectory}*`);
+        } catch {}
+    } else {
+        fs.mkdirSync(artifactDirectory);
+    }
+};
+
+// @ts-check
+/**
+ * @param {import('../types').Extension} extension
+ * @param {import('../types').PublishContext} publishContext
+ */
+async function buildVersion(extension, publishContext) {
+    console.debug(`Building ${extension.id} for ${publishContext.target || "universal"}...`);  
+    console.log(`\nProcessing extension: ${JSON.stringify({ extension, publishContext }, undefined, 2)}`);
+    try {
+        await ensureBuildPrerequisites();
+        const { id } = extension;
+        let packagePath = publishContext.repo;
         if (packagePath && extension.location) {
             packagePath = path.join(packagePath, extension.location);
         }
 
         /** @type {import('ovsx').PublishOptions} */
         let options;
-        if (context.file) {
-            options = { extensionFile: context.file, targets: [context.target] };
-        } else if (context.repo && context.ref) {
-            console.log(`${id}: preparing from ${context.repo}...`);
+        if (publishContext.file) {
+            options = { extensionFile: publishContext.file, targets: [publishContext.target] };
+        } else if (publishContext.repo && publishContext.ref) {
+            console.log(`${id}: preparing from ${publishContext.repo}...`);
+            await resolveExtension(
+                extension,
+                publishContext.msVersion && {
+                    version: publishContext.msVersion,
+                    lastUpdated: publishContext.msLastUpdated,
+                },
+            );
 
             const [publisher, name] = extension.id.split(".");
             process.env.EXTENSION_ID = extension.id;
             process.env.EXTENSION_PUBLISHER = publisher;
             process.env.EXTENSION_NAME = name;
-            process.env.VERSION = context.version;
-            process.env.MS_VERSION = context.msVersion;
-            process.env.OVSX_VERSION = context.ovsxVersion;
-            await exec(`git checkout ${context.ref}`, { cwd: context.repo });
+            process.env.VERSION = publishContext.version;
+            process.env.MS_VERSION = publishContext.msVersion;
+            process.env.OVSX_VERSION = publishContext.ovsxVersion;
+            await exec(`git checkout ${publishContext.ref}`, { cwd: publishContext.repo });
 
             try {
-                const nvmFile = await findUp(".nvmrc", { cwd: path.join(context.repo, extension.location ?? ".") });
+                const nvmFile = await findUp(".nvmrc", { cwd: path.join(publishContext.repo, extension.location ?? ".") });
                 if (nvmFile) {
                     // If the project has a preferred Node version, use it
                     await exec("source ~/.nvm/nvm.sh && nvm install", {
-                        cwd: path.join(context.repo, extension.location ?? "."),
+                        cwd: path.join(publishContext.repo, extension.location ?? "."),
                         quiet: true,
                     });
                 }
@@ -79,7 +106,7 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
                     console.debug("Installing appropriate Python version...");
                     await exec(
                         `pyenv install -s ${extension.pythonVersion} && pyenv global ${extension.pythonVersion}`,
-                        { cwd: path.join(context.repo, extension.location ?? "."), quiet: false },
+                        { cwd: path.join(publishContext.repo, extension.location ?? "."), quiet: false },
                     );
                 }
             } catch {}
@@ -87,34 +114,34 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
             if (extension.custom) {
                 try {
                     for (const command of extension.custom) {
-                        await exec(command, { cwd: context.repo });
+                        await exec(command, { cwd: publishContext.repo });
                     }
 
                     options = {
                         extensionFile: path.join(
-                            context.repo,
+                            publishContext.repo,
                             extension.location ?? ".",
                             extension.extensionFile ?? "extension.vsix",
                         ),
                     };
 
-                    if (context.target) {
-                        console.info(`Looking for a ${context.target} vsix package in ${context.repo}...`);
-                        const vsixFiles = await fg(path.join(`*-${context.target}-*.vsix`), {
-                            cwd: context.repo,
+                    if (publishContext.target) {
+                        console.info(`Looking for a ${publishContext.target} vsix package in ${publishContext.repo}...`);
+                        const vsixFiles = await fg(path.join(`*-${publishContext.target}-*.vsix`), {
+                            cwd: publishContext.repo,
                             onlyFiles: true,
                         });
                         if (vsixFiles.length > 0) {
                             console.info(
-                                `Found ${vsixFiles.length} ${context.target} vsix package(s) in ${context.repo}: ${vsixFiles.join(", ")}`,
+                                `Found ${vsixFiles.length} ${publishContext.target} vsix package(s) in ${publishContext.repo}: ${vsixFiles.join(", ")}`,
                             );
                             options = {
-                                extensionFile: path.join(context.repo, vsixFiles[0]),
-                                targets: [context.target],
+                                extensionFile: path.join(publishContext.repo, vsixFiles[0]),
+                                targets: [publishContext.target],
                             };
                         } else {
                             throw new Error(
-                                `After running the custom commands, no .vsix file was found for ${extension.id}@${context.target}`,
+                                `After running the custom commands, no .vsix file was found for ${extension.id}@${publishContext.target}`,
                             );
                         }
                     }
@@ -123,7 +150,7 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
                 }
             } else {
                 const yarn = await new Promise((resolve) => {
-                    fs.access(path.join(context.repo, "yarn.lock"), (error) => resolve(!error));
+                    fs.access(path.join(publishContext.repo, "yarn.lock"), (error) => resolve(!error));
                 });
                 try {
                     await exec(`${yarn ? "yarn" : "npm"} install`, { cwd: packagePath });
@@ -146,12 +173,12 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
                     }
                 }
                 if (extension.prepublish) {
-                    await exec(extension.prepublish, { cwd: context.repo });
+                    await exec(extension.prepublish, { cwd: publishContext.repo });
                 }
                 if (extension.extensionFile) {
-                    options = { extensionFile: path.join(context.repo, extension.extensionFile) };
+                    options = { extensionFile: path.join(publishContext.repo, extension.extensionFile) };
                 } else {
-                    options = { extensionFile: path.join(context.repo, "extension.vsix") };
+                    options = { extensionFile: path.join(publishContext.repo, "extension.vsix") };
                     if (yarn) {
                         options.yarn = true;
                     }
@@ -165,31 +192,31 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
                             baseContentUrl: options.baseContentUrl,
                             baseImagesUrl: options.baseImagesUrl,
                             useYarn: options.yarn,
-                            target: context.target,
+                            target: publishContext.target,
                         });
                     } finally {
                         process.env["VSCE_TESTS"] = vsceTests;
                     }
                 }
-                console.log(`${id}: prepared from ${context.repo}`);
+                console.log(`${id}: prepared from ${publishContext.repo}`);
             }
         }
 
         // Check if the requested version is greater than the one on Open VSX.
         const { xmlManifest, manifest } = options.extensionFile && (await readVSIXPackage(options.extensionFile));
-        context.version = xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Version || manifest?.version;
-        if (!context.version) {
+        publishContext.version = xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Version || manifest?.version;
+        if (!publishContext.version) {
             throw new Error(`${extension.id}: version is not resolved`);
         }
 
-        if (context.ovsxVersion) {
-            if (semver.gt(context.ovsxVersion, context.version)) {
+        if (publishContext.ovsxVersion) {
+            if (semver.gt(publishContext.ovsxVersion, publishContext.version)) {
                 throw new Error(
-                    `extensions.json is out-of-date: Open VSX version ${context.ovsxVersion} is already greater than specified version ${context.version}`,
+                    `extensions.json is out-of-date: Open VSX version ${publishContext.ovsxVersion} is already greater than specified version ${publishContext.version}`,
                 );
             }
-            if (semver.eq(context.ovsxVersion, context.version) && process.env.FORCE !== "true") {
-                console.log(`[SKIPPED] Requested version ${context.version} is already published on Open VSX`);
+            if (semver.eq(publishContext.ovsxVersion, publishContext.version) && process.env.FORCE !== "true") {
+                console.log(`[SKIPPED] Requested version ${publishContext.version} is already published on Open VSX`);
                 return;
             }
         }
@@ -216,6 +243,7 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
             }
 
             const dependenciesNotOnOpenVsx = [];
+            const extensions = JSON.parse(await fs.promises.readFile("./extensions.json", "utf-8"));
             for (const dependency of extensionDependenciesNotBuiltin) {
                 if (process.env.SKIP_PUBLISH && Object.keys(extensions).find((key) => key === dependency)) {
                     continue;
@@ -234,42 +262,20 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
             }
         }
 
-        if (options.extensionFile && process.env.EXTENSIONS) {
+        if (options.extensionFile) {
             console.info(`Copying file to ${artifactDirectory}`);
-            const outputFile = `${extension.id}${context.target ? `@${context.target}` : ""}.vsix`;
-            fs.copyFileSync(options.extensionFile, path.join("/tmp/artifacts/", outputFile));
+            const outputPath =  path.join(artifactDirectory, `${extension.id}${publishContext.target ? `@${publishContext.target}` : ""}.vsix`);
+            fs.copyFileSync(options.extensionFile, outputPath);
+            options.extensionFile = outputPath;
         }
 
-        if (process.env.SKIP_PUBLISH === "true") {
-            return;
-        }
-
-        console.log(`Attempting to publish ${id} to Open VSX`);
-
-        // Create a public Open VSX namespace if needed.
-        try {
-            await ovsx.createNamespace({ name: namespace });
-        } catch (error) {
-            console.log(`Creating Open VSX namespace failed -- assuming that it already exists`);
-            console.log(error);
-        }
-
-        console.info(`Publishing extension as ${options.targets ? options.targets.join(", ") : "universal"}`);
-        if (process.env.OVSX_PAT) {
-            await ovsx.publish(options);
-            console.log(`Published ${id} to https://${registryHost}/extension/${id.split(".")[0]}/${id.split(".")[1]}`);
-        } else {
-            console.error(
-                "The OVSX_PAT environment variable was not provided, which means the extension cannot be published. Provide it or set SKIP_PUBLISH to true to avoid seeing this.",
-            );
-            process.exitCode = 1;
-        }
+        return options;
     } catch (error) {
         if (error && String(error).indexOf("is already published.") !== -1) {
             console.log(`Could not process extension -- assuming that it already exists`);
             console.log(error);
         } else {
-            console.error(`[FAIL] Could not process extension: ${JSON.stringify({ extension, context }, null, 2)}`);
+            console.error(`[FAIL] Could not process extension: ${JSON.stringify({ extension, publishContext }, null, 2)}`);
             console.error(error);
             process.exitCode = 1;
         }
@@ -279,4 +285,67 @@ openGalleryApi.post = (url, data, additionalHeaders) =>
             await exec(`pyenv global ${defaultPythonVersion}`);
         }
     }
-})();
+}
+
+// @ts-check
+/** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+module.exports = async({core}) => {
+    const extension = JSON.parse(process.env.EXTENSION);
+    const publishContext = JSON.parse(process.env.PUBLISH_CONTEXT);
+    publishContext.msLastUpdated = new Date(publishContext.msLastUpdated);
+    publishContext.ovsxLastUpdated = new Date(publishContext.ovsxLastUpdated);
+
+    const allOptions = [];
+    if (publishContext.files) {
+        // Build all targets of extension from GitHub Release assets
+        for (const [target, file] of Object.entries(publishContext.files)) {
+            if (!extension.target || Object.keys(extension.target).includes(target)) {
+                publishContext.file = file;
+                publishContext.target = target;
+                const options = await buildVersion(extension, publishContext);
+                if(options) {
+                    allOptions.push(options);
+                }
+            } else {
+                console.log(`${extension.id}: skipping, since target ${target} is not included`);
+            }
+        }
+    } else if (extension.target) {
+        // Build all specified targets of extension from sources
+        for (const [target, targetData] of Object.entries(extension.target)) {
+            publishContext.target = target;
+            if (targetData !== true) {
+                publishContext.environmentVariables = targetData.env;
+            }
+            const options = await buildVersion(extension, publishContext);
+            if(options) {
+                allOptions.push(options);
+            }
+        }
+    } else {
+        // Build only the universal target of extension from sources
+        const options = await buildVersion(extension, publishContext);
+        if(options) {
+            allOptions.push(options);
+        }
+    }
+
+    const extensionFiles = [];
+    for(const options of allOptions) {
+        if (options.extensionFile) {
+            extensionFiles.push(options.extensionFile);
+        }
+    }
+
+    const artifact = new DefaultArtifactClient();
+    await artifact.uploadArtifact(
+        'artifacts', 
+        extensionFiles,
+        artifactDirectory,
+        {
+            retentionDays: 7
+        }
+    ); 
+
+    core.setOutput('extensionFiles', JSON.stringify(extensionFiles));
+};

--- a/scripts/download-extension.js
+++ b/scripts/download-extension.js
@@ -1,0 +1,38 @@
+/** ******************************************************************************
+ * Copyright (c) 2025 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+const path = require("path");
+const {DefaultArtifactClient} = require('@actions/artifact')
+const resolveExtension = require("../lib/resolveExtension").resolveExtension;
+
+module.exports = async () => {
+    const extension = JSON.parse(process.env.EXTENSION);
+    console.debug(`Resolving downloads for ${extension.id}`);  
+
+    const publishContext = JSON.parse(process.env.PUBLISH_CONTEXT);
+    publishContext.msLastUpdated = new Date(publishContext.msLastUpdated);
+    publishContext.ovsxLastUpdated = new Date(publishContext.ovsxLastUpdated);
+    await resolveExtension(
+        extension,
+        publishContext.msVersion && {
+            version: publishContext.msVersion,
+            lastUpdated: publishContext.msLastUpdated,
+        },
+    );
+
+    const artifact = new DefaultArtifactClient();
+    await artifact.uploadArtifact(
+        'download', 
+        Object.values(publishContext.files),
+        '/tmp/download',
+        {
+            retentionDays: 7
+        }
+    ); 
+};

--- a/scripts/download-extension.js
+++ b/scripts/download-extension.js
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  * ****************************************************************************** */
 const path = require("path");
-const {DefaultArtifactClient} = require('@actions/artifact')
+const { DefaultArtifactClient } = require("@actions/artifact");
 const resolveExtension = require("../lib/resolveExtension").resolveExtension;
 
 module.exports = async () => {
     const extension = JSON.parse(process.env.EXTENSION);
-    console.debug(`Resolving downloads for ${extension.id}`);  
+    console.debug(`Resolving downloads for ${extension.id}`);
 
     const publishContext = JSON.parse(process.env.PUBLISH_CONTEXT);
     publishContext.msLastUpdated = new Date(publishContext.msLastUpdated);
@@ -27,12 +27,7 @@ module.exports = async () => {
     );
 
     const artifact = new DefaultArtifactClient();
-    await artifact.uploadArtifact(
-        'download', 
-        Object.values(publishContext.files),
-        '/tmp/download',
-        {
-            retentionDays: 7
-        }
-    ); 
+    await artifact.uploadArtifact("download", Object.values(publishContext.files), "/tmp/download", {
+        retentionDays: 7,
+    });
 };

--- a/scripts/publish-extension.js
+++ b/scripts/publish-extension.js
@@ -1,0 +1,109 @@
+/********************************************************************************
+ * Copyright (c) 2023 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+// @ts-check
+const ovsx = require("ovsx");
+const yauzl = require('yauzl-promise');
+const xml2js = require('xml2js');
+
+const { registryHost } = require("../lib/constants");
+
+/**
+ *
+ * @param {Readonly<import('stream').Readable>} stream
+ * @returns {Promise<Buffer>}
+ */
+async function bufferStream(stream) {
+	return await new Promise((resolve, reject) => {
+        /** @type {Array<Buffer>} */
+		const buffers = [];
+		stream.on('data', buffer => buffers.push(buffer));
+		stream.once('error', reject);
+		stream.once('end', () => resolve(Buffer.concat(buffers)));
+	});
+}
+
+/**
+ *
+ * @param {string} packagePath
+ * @param {(name: string) => boolean} filter
+ * @returns {Promise<Map<string, Buffer>>}
+ */
+async function readZip(packagePath, filter) {
+	const result = new Map();
+	const zipfile = await yauzl.open(packagePath);
+	try {
+		for await (const entry of zipfile) {
+			if (filter(entry.filename)) {
+				const stream = await zipfile.openReadStream(entry);
+				const buffer = await bufferStream(stream);
+				result.set(entry.filename, buffer);
+			}
+		}
+	} finally {
+		await zipfile.close();
+	}
+
+	return result;
+}
+
+/**
+ *
+ * @param {string} extensionFile
+ * @returns {Promise<any|undefined>}
+ */
+async function readXmlManifest(extensionFile) {
+    const fileName = 'extension.vsixmanifest';
+    const result = await readZip(extensionFile, name => name === fileName);
+    const rawFile = result.get(fileName);
+    if(rawFile == null) {
+        return undefined;
+    }
+
+    const xml = rawFile.toString('utf-8');
+    const parser = new xml2js.Parser();
+    return await parser.parseStringPromise(xml);
+}
+
+module.exports = async() => {
+    const extensionId = process.env.EXTENSION_ID;
+    const [namespace, extension] = extensionId.split(".");
+    console.log(`Attempting to publish ${extensionId} to Open VSX`);
+    if (!process.env.OVSX_PAT) {
+        throw new Error("The OVSX_PAT environment variable was not provided, which means the extension cannot be published. Provide it or set SKIP_PUBLISH to true to avoid seeing this.");
+    }
+
+    const registryUrl = `https://${registryHost}`;
+    const files = JSON.parse(process.env.EXTENSION_FILES);
+    for(const extensionFile of files) {
+        const xmlManifest = await readXmlManifest(extensionFile);
+        if(xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Publisher.toLowerCase() != namespace.toLowerCase()) {
+            console.error(`Namespace name mismatch. Expected ${namespace}, but found ${xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Publisher}`);
+            continue;
+        } 
+        if(xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Id.toLowerCase() != extension.toLowerCase()) {
+            console.error(`Extension name mismatch. Expected ${extension}, but found ${xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Id}`);
+            continue;
+        }
+
+        // Create a public Open VSX namespace if needed.
+        try {
+            await ovsx.createNamespace({ name: namespace, registryUrl });
+        } catch (error) {
+            console.log(`Creating Open VSX namespace failed -- assuming that it already exists`);
+            console.log(error);
+        }
+
+        console.info(`Publishing extension ${extensionId}`);
+        const options = {extensionFile, registryUrl};
+        await ovsx.publish(options);
+        console.log(`Published ${options.extensionFile} to ${options.registryUrl}/extension/${namespace}/${extension}`);
+    }
+};

--- a/scripts/publish-extension.js
+++ b/scripts/publish-extension.js
@@ -10,8 +10,8 @@
 
 // @ts-check
 const ovsx = require("ovsx");
-const yauzl = require('yauzl-promise');
-const xml2js = require('xml2js');
+const yauzl = require("yauzl-promise");
+const xml2js = require("xml2js");
 
 const { registryHost } = require("../lib/constants");
 
@@ -21,13 +21,13 @@ const { registryHost } = require("../lib/constants");
  * @returns {Promise<Buffer>}
  */
 async function bufferStream(stream) {
-	return await new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
         /** @type {Array<Buffer>} */
-		const buffers = [];
-		stream.on('data', buffer => buffers.push(buffer));
-		stream.once('error', reject);
-		stream.once('end', () => resolve(Buffer.concat(buffers)));
-	});
+        const buffers = [];
+        stream.on("data", (buffer) => buffers.push(buffer));
+        stream.once("error", reject);
+        stream.once("end", () => resolve(Buffer.concat(buffers)));
+    });
 }
 
 /**
@@ -37,21 +37,21 @@ async function bufferStream(stream) {
  * @returns {Promise<Map<string, Buffer>>}
  */
 async function readZip(packagePath, filter) {
-	const result = new Map();
-	const zipfile = await yauzl.open(packagePath);
-	try {
-		for await (const entry of zipfile) {
-			if (filter(entry.filename)) {
-				const stream = await zipfile.openReadStream(entry);
-				const buffer = await bufferStream(stream);
-				result.set(entry.filename, buffer);
-			}
-		}
-	} finally {
-		await zipfile.close();
-	}
+    const result = new Map();
+    const zipfile = await yauzl.open(packagePath);
+    try {
+        for await (const entry of zipfile) {
+            if (filter(entry.filename)) {
+                const stream = await zipfile.openReadStream(entry);
+                const buffer = await bufferStream(stream);
+                result.set(entry.filename, buffer);
+            }
+        }
+    } finally {
+        await zipfile.close();
+    }
 
-	return result;
+    return result;
 }
 
 /**
@@ -60,36 +60,48 @@ async function readZip(packagePath, filter) {
  * @returns {Promise<any|undefined>}
  */
 async function readXmlManifest(extensionFile) {
-    const fileName = 'extension.vsixmanifest';
-    const result = await readZip(extensionFile, name => name === fileName);
+    const fileName = "extension.vsixmanifest";
+    const result = await readZip(extensionFile, (name) => name === fileName);
     const rawFile = result.get(fileName);
-    if(rawFile == null) {
+    if (rawFile == null) {
         return undefined;
     }
 
-    const xml = rawFile.toString('utf-8');
+    const xml = rawFile.toString("utf-8");
     const parser = new xml2js.Parser();
     return await parser.parseStringPromise(xml);
 }
 
-module.exports = async() => {
-    const extensionId = process.env.EXTENSION_ID;
+// @ts-check
+/**
+ * @param {string} extensionId
+ * @param {string[]} extensionFiles
+ */
+module.exports = async (extensionId, extensionFiles) => {
     const [namespace, extension] = extensionId.split(".");
     console.log(`Attempting to publish ${extensionId} to Open VSX`);
     if (!process.env.OVSX_PAT) {
-        throw new Error("The OVSX_PAT environment variable was not provided, which means the extension cannot be published. Provide it or set SKIP_PUBLISH to true to avoid seeing this.");
+        throw new Error(
+            "The OVSX_PAT environment variable was not provided, which means the extension cannot be published. Provide it or set SKIP_PUBLISH to true to avoid seeing this.",
+        );
     }
 
     const registryUrl = `https://${registryHost}`;
-    const files = JSON.parse(process.env.EXTENSION_FILES);
-    for(const extensionFile of files) {
+    for (const extensionFile of extensionFiles) {
         const xmlManifest = await readXmlManifest(extensionFile);
-        if(xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Publisher.toLowerCase() != namespace.toLowerCase()) {
-            console.error(`Namespace name mismatch. Expected ${namespace}, but found ${xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Publisher}`);
+        if (
+            xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Publisher.toLowerCase() !=
+            namespace.toLowerCase()
+        ) {
+            console.error(
+                `Namespace name mismatch. Expected ${namespace}, but found ${xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Publisher}`,
+            );
             continue;
-        } 
-        if(xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Id.toLowerCase() != extension.toLowerCase()) {
-            console.error(`Extension name mismatch. Expected ${extension}, but found ${xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Id}`);
+        }
+        if (xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Id.toLowerCase() != extension.toLowerCase()) {
+            console.error(
+                `Extension name mismatch. Expected ${extension}, but found ${xmlManifest?.PackageManifest?.Metadata[0]?.Identity[0]["$"]?.Id}`,
+            );
             continue;
         }
 
@@ -102,7 +114,7 @@ module.exports = async() => {
         }
 
         console.info(`Publishing extension ${extensionId}`);
-        const options = {extensionFile, registryUrl};
+        const options = { extensionFile, registryUrl };
         await ovsx.publish(options);
         console.log(`Published ${options.extensionFile} to ${options.registryUrl}/extension/${namespace}/${extension}`);
     }

--- a/scripts/publish-extensions.js
+++ b/scripts/publish-extensions.js
@@ -10,6 +10,7 @@
 
 // @ts-check
 const fs = require("fs");
+const { RateLimiter } = require('limiter');
 const { getPublicGalleryAPI } = require("@vscode/vsce/out/util");
 const { PublicGalleryAPI } = require("@vscode/vsce/out/publicgalleryapi");
 const { ExtensionQueryFlags, PublishedExtension } = require("azure-devops-node-api/interfaces/GalleryInterfaces");
@@ -90,6 +91,7 @@ module.exports = async (doPublish) => {
     };
     const monthAgo = new Date();
     monthAgo.setMonth(monthAgo.getMonth() - 1);
+    const limiter = new RateLimiter({ tokensPerInterval: 50, interval: 'second' });
     for (const id in extensions) {
         if (id === "$schema") {
             continue;
@@ -269,6 +271,7 @@ module.exports = async (doPublish) => {
                 continue;
             }
 
+            await limiter.removeTokens(1);
             await doPublish(extension, context);
         } catch (error) {
             stat.failed.push(extension.id);

--- a/scripts/publish-extensions.js
+++ b/scripts/publish-extensions.js
@@ -10,35 +10,18 @@
 
 // @ts-check
 const fs = require("fs");
-const cp = require("child_process");
 const { getPublicGalleryAPI } = require("@vscode/vsce/out/util");
 const { PublicGalleryAPI } = require("@vscode/vsce/out/publicgalleryapi");
 const { ExtensionQueryFlags, PublishedExtension } = require("azure-devops-node-api/interfaces/GalleryInterfaces");
 const semver = require("semver");
 const Ajv = require("ajv/dist/2020").default;
-const resolveExtension = require("./lib/resolveExtension").resolveExtension;
-const exec = require("./lib/exec");
-const { artifactDirectory, registryHost } = require("./lib/constants");
-
-const msGalleryApi = getPublicGalleryAPI();
-msGalleryApi.client["_allowRetries"] = true;
-msGalleryApi.client["_maxRetries"] = 5;
-
-const openGalleryApi = new PublicGalleryAPI(`https://${registryHost}/vscode`, "3.0-preview.1");
-openGalleryApi.client["_allowRetries"] = true;
-openGalleryApi.client["_maxRetries"] = 5;
-openGalleryApi.post = (url, data, additionalHeaders) =>
-    openGalleryApi.client.post(`${openGalleryApi.baseUrl}${url}`, data, additionalHeaders);
-
-const flags = [
-    ExtensionQueryFlags.IncludeStatistics,
-    ExtensionQueryFlags.IncludeVersions,
-    ExtensionQueryFlags.IncludeVersionProperties,
-];
+const resolveExtension = require("../lib/resolveExtension").resolveExtension;
+const exec = require("../lib/exec");
+const { registryHost } = require("../lib/constants");
 
 /**
  * Checks whether the provided `version` is a prerelease or not
- * @param {Readonly<import('./types').IRawGalleryExtensionProperty[]>} version
+ * @param {Readonly<import('../types').IRawGalleryExtensionProperty[]>} version
  * @returns
  */
 function isPreReleaseVersion(version) {
@@ -46,26 +29,24 @@ function isPreReleaseVersion(version) {
     return values.length > 0 && values[0].value === "true";
 }
 
-const ensureBuildPrerequisites = async () => {
-    // Make yarn use bash
-    await exec("yarn config set script-shell /bin/bash");
+// @ts-check
+/** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+module.exports = async ({github}) => {
+    const msGalleryApi = getPublicGalleryAPI();
+    msGalleryApi.client["_allowRetries"] = true;
+    msGalleryApi.client["_maxRetries"] = 5;
 
-    // Don't show large git advice blocks
-    await exec("git config --global advice.detachedHead false");
+    const openGalleryApi = new PublicGalleryAPI(`https://${registryHost}/vscode`, "3.0-preview.1");
+    openGalleryApi.client["_allowRetries"] = true;
+    openGalleryApi.client["_maxRetries"] = 5;
+    openGalleryApi.post = (url, data, additionalHeaders) =>
+        openGalleryApi.client.post(`${openGalleryApi.baseUrl}${url}`, data, additionalHeaders);
 
-    // Create directory for storing built extensions
-    if (fs.existsSync(artifactDirectory)) {
-        // If the folder has any files, delete them
-        try {
-            fs.rmSync(`${artifactDirectory}*`);
-        } catch {}
-    } else {
-        fs.mkdirSync(artifactDirectory);
-    }
-};
-
-(async () => {
-    await ensureBuildPrerequisites();
+    const flags = [
+        ExtensionQueryFlags.IncludeStatistics,
+        ExtensionQueryFlags.IncludeVersions,
+        ExtensionQueryFlags.IncludeVersionProperties,
+    ];
 
     /**
      * @type {string[] | undefined}
@@ -75,7 +56,7 @@ const ensureBuildPrerequisites = async () => {
         toVerify = process.env.EXTENSIONS === "," ? [] : process.env.EXTENSIONS.split(",").map((s) => s.trim());
     }
     /**
-     * @type {Readonly<import('./types').Extensions>}
+     * @type {Readonly<import('../types').Extensions>}
      */
     const extensions = JSON.parse(await fs.promises.readFile("./extensions.json", "utf-8"));
 
@@ -94,7 +75,7 @@ const ensureBuildPrerequisites = async () => {
     // Also install extensions' devDependencies when using `npm install` or `yarn install`.
     process.env.NODE_ENV = "development";
 
-    /** @type{import('./types').PublishStat}*/
+    /** @type{import('../types').PublishStat}*/
     const stat = {
         upToDate: {},
         outdated: {},
@@ -117,7 +98,7 @@ const ensureBuildPrerequisites = async () => {
             continue;
         }
         const extension = Object.freeze({ id, ...extensions[id] });
-        /** @type {import('./types').PublishContext} */
+        /** @type {import('../types').PublishContext} */
         const context = {};
         let timeoutDelay = Number(extension.timeout);
         if (!Number.isInteger(timeoutDelay)) {
@@ -288,81 +269,30 @@ const ensureBuildPrerequisites = async () => {
                 continue;
             }
 
-            let timeout;
-
-            const publishVersion = async (extension, context) => {
-                const env = {
-                    ...process.env,
-                    ...context.environmentVariables,
-                };
-
-                console.debug(`Publishing ${extension.id} for ${context.target || "universal"}...`);
-
-                await new Promise((resolve, reject) => {
-                    const p = cp.spawn(
-                        process.execPath,
-                        ["publish-extension.js", JSON.stringify({ extension, context, extensions })],
-                        {
-                            stdio: ["ignore", "inherit", "inherit"],
-                            cwd: process.cwd(),
-                            env,
-                        },
-                    );
-                    p.on("error", reject);
-                    p.on("exit", (code) => {
-                        if (code) {
-                            return reject(new Error("failed with exit status: " + code));
-                        }
-                        resolve("done");
-                    });
-                    timeout = setTimeout(
-                        () => {
-                            try {
-                                p.kill("SIGKILL");
-                            } catch {}
-                            reject(new Error(`timeout after ${timeoutDelay} mins`));
-                        },
-                        timeoutDelay * 60 * 1000,
-                    );
-                });
-                if (timeout !== undefined) {
-                    clearTimeout(timeout);
+            const [owner,repo] = process.env.REPOSITORY.split("/");
+            await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+                owner,
+                repo,
+                workflow_id: 'publish-extension.yml',
+                ref: 'master',
+                inputs: {
+                  extension: JSON.stringify(extension),
+                  publishContext: JSON.stringify(context),
+                  force: process.env.FORCE,
+                  skipPublish: process.env.SKIP_PUBLISH
+                },
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
                 }
-            };
-
-            if (context.files) {
-                // Publish all targets of extension from GitHub Release assets
-                for (const [target, file] of Object.entries(context.files)) {
-                    if (!extension.target || Object.keys(extension.target).includes(target)) {
-                        context.file = file;
-                        context.target = target;
-                        await publishVersion(extension, context);
-                    } else {
-                        console.log(`${extension.id}: skipping, since target ${target} is not included`);
-                    }
-                }
-            } else if (extension.target) {
-                // Publish all specified targets of extension from sources
-                for (const [target, targetData] of Object.entries(extension.target)) {
-                    context.target = target;
-                    if (targetData !== true) {
-                        context.environmentVariables = targetData.env;
-                    }
-                    await publishVersion(extension, context);
-                }
-            } else {
-                // Publish only the universal target of extension from sources
-                await publishVersion(extension, context);
-            }
-
-            await updateStat();
+            });
         } catch (error) {
             stat.failed.push(extension.id);
-            console.error(`[FAIL] Could not process extension: ${JSON.stringify({ extension, context }, null, 2)}`);
+            console.error(`[FAIL] Could not process extension: ${JSON.stringify({ extension, publishContext: context }, null, 2)}`);
             console.error(error);
         }
     }
 
+    // TODO how to collect stats with multi stage workflow?
     await fs.promises.writeFile("/tmp/stat.json", JSON.stringify(stat), { encoding: "utf8" });
     process.exit();
-})();
+}

--- a/scripts/upload-artifacts.js
+++ b/scripts/upload-artifacts.js
@@ -1,0 +1,13 @@
+const { DefaultArtifactClient } = require("@actions/artifact");
+const { artifactDirectory } = require("../lib/constants");
+
+// @ts-check
+/**
+ * @param {string[]} extensionFiles
+ */
+module.exports = async (extensionFiles) => {
+    const artifact = new DefaultArtifactClient();
+    await artifact.uploadArtifact("artifacts", extensionFiles, artifactDirectory, {
+        retentionDays: 7,
+    });
+};


### PR DESCRIPTION
This PR introduces the use of separate jobs instead of child_process to sandbox the extension build process.
