### PR TITLE
Deprecate dieghernan.oveflow-theme

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -29,6 +29,13 @@
     ],
     "deprecated": {
         "andrewhertog.codex-editor-extension": true,
+        "dieghernan.oveflow-theme": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "dieghernan.overflow-theme",
+                "displayName": "Overflow Theme"
+            }
+        },
         "decodetalkers.neocmake-lsp-vscode": {
             "disallowInstall": false,
             "extension": {


### PR DESCRIPTION
-   [X] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [ ] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR introduces a request for deprecating one of my published extensions:
- https://open-vsx.org/extension/dieghernan/oveflow-theme

Additionally, the replacement extension https://open-vsx.org/extension/dieghernan/overflow-theme (note the **r** in the id) should be suggested. 

Regards
