### PR TITLE
Address swift extension rename

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -482,6 +482,13 @@
                 "displayName": "Bazel Kotlin"
             }
         },
+        "sswg.swift-lang": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "swiftlang.swift-vscode",
+                "displayName": "Swift"
+            }
+        },
         "DrMerfy.overtype": true,
         "jroesch.lean": true,
         "moalamri.inline-fold": true,

--- a/extensions.json
+++ b/extensions.json
@@ -1343,8 +1343,8 @@
   "sorbet.sorbet-vscode-extension": {
     "repository": "https://github.com/sorbet/sorbet"
   },
-  "sswg.swift-lang": {
-    "repository": "https://github.com/swift-server/vscode-swift"
+  "swiftlang.swift-vscode": {
+    "repository": "https://github.com/swiftlang/vscode-swift"
   },
   "steoates.autoimport": {
     "repository": "https://github.com/soates/Auto-Import"


### PR DESCRIPTION
Publishes the extension under the new namespace.

Also deprecated the old in favor of the renamed version.

Thanks @NSHaoSong for pointing this out in https://github.com/EclipseFdn/publish-extensions/pull/721#issuecomment-2910380807!