### PR TITLE
[optify] Add Optify extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1162,6 +1162,10 @@
   "openfl.lime-vscode-extension": {
     "repository": "https://github.com/openfl/lime-vscode-extension"
   },
+  "optify-config.optify": {
+    "repository": "https://github.com/juharris/optify",
+    "location": "vscode/extension"
+  },
   "paiqo.databricks-vscode": {
     "repository": "https://github.com/paiqo/Databricks-VSCode"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)). _I am the maintainer, but I want the extension to be automatically published because this feels more legitimate._
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description
Add Optify extension.

I followed the guidelines in https://github.com/EclipseFdn/open-vsx.org/wiki/Auto-Publishing-Extensions#request-an-extension-be-auto-published

I have [a GitHub action](https://github.com/juharris/optify/blob/main/.github/workflows/vsc_extension-build_test.yml) to publish it to the VS Marketplace. Here is the published extension: https://marketplace.visualstudio.com/items?itemName=optify-config.optify

I didn't realize that extensions could be automatically published to Open VSX so I already manually published this one: https://open-vsx.org/extension/optify-config/optify
but I would rather it get automatically published and look more legit, I hope that's alright.
