### PR TITLE
Add code muse light theme

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1210,6 +1210,9 @@
   "rafaelmaiolla.diff": {
     "repository": "https://github.com/rafaelmaiolla/diff-vscode"
   },
+  "rajankur.code-muse-light-theme": {
+    "repository": "https://github.com/rafaelmaiolla/diff-vscode"
+  },
   "RandomChance.logstash": {
     "repository": "https://github.com/randomchance/vscode-logstash-configuration-syntax"
   },

--- a/extensions.json
+++ b/extensions.json
@@ -1211,7 +1211,7 @@
     "repository": "https://github.com/rafaelmaiolla/diff-vscode"
   },
   "rajankur.code-muse-light-theme": {
-    "repository": "https://github.com/rafaelmaiolla/diff-vscode"
+    "repository": "https://github.com/rajankur/code-muse-theme"
   },
   "RandomChance.logstash": {
     "repository": "https://github.com/randomchance/vscode-logstash-configuration-syntax"


### PR DESCRIPTION
This PR adds the [code-muse-light-theme](https://github.com/rajankur/code-muse-theme) extension to the Open VSX registry.
It is a custom light theme inspired by GitHub’s aesthetics, created and maintained by me as the official author.

I am submitting this PR to seed the extension into the registry under my own namespace (rajankur) as per Open VSX guidelines. I have created the necessary metadata and published the initial version for public use.
	•	Extension repository: https://github.com/rajankur/code-muse-light-theme
	•	Open source license: MIT
	•	Maintainer: @rajankur (myself)
	•	The extension is actively maintained and intended to be published officially by the author.

⸻

Also make sure to tick these checkboxes above the description (if applicable):

✅ I have read the note above about PRs contributing or fixing extensions
✅ I have tried reaching out to the extension maintainers (N/A, I am the maintainer)
✅ This extension has an OSI-approved OSS license (MIT)