### PR TITLE
Deprecate dschibster.sf-org-list

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -50,6 +50,13 @@
         }
     ],
     "deprecated": {
+        "dschibster.sf-org-list" : {
+            "disallowInstall": true,
+            "extension": {
+                "id": "dennisgrzyb.sf-org-list",
+                "displayName": "SF Org List"
+            }
+        },
         "andrewhertog.codex-editor-extension": true,
         "Daimler.sechub": {
             "disallowInstall": true,
@@ -396,7 +403,7 @@
             "extension": {
                 "id": "mark-wiemer.vscode-autohotkey-plus-plus",
                 "displayName": "AutoHotkey Plus Plus"
-            }
+            }Published 11 minutes ago
         },
         "mark-wiemer.ahk-v1-formatter": {
             "disallowInstall": true,


### PR DESCRIPTION


## Description

This PR deprecates the duplicate extension published under a second namespace. From now on with me having claimed the namespace, I can continue simply publishing under the unified "dennisgrzyb" namespace. In order to not lead to a henceforth unmaintained extension I would like get rid of it.
