### PR TITLE
Add the JupyterHub extension to the build script

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -929,6 +929,9 @@
   "ms-toolsai.jupyter-keymap": {
     "repository": "https://github.com/microsoft/vscode-jupyter-keymap"
   },
+  "ms-toolsai.jupyter-hub": {
+    "repository": "https://github.com/jupyterhub/jupyterhub",
+  },
   "ms-toolsai.jupyter-renderers": {
     "repository": "https://github.com/Microsoft/vscode-notebook-renderers",
     "timeout": 30


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).

I did not, as this extension is published and maintained by Microsoft.

-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the JupyterHub extension to the build script. This extension is OSS under the BSD-3-Clause license

https://github.com/jupyterhub/jupyterhub

https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter-hub
