### PR TITLE
Deprecate codescene.codescene-vscode-noace

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -60,6 +60,13 @@
         }
     ],
     "deprecated": {
+        "codescene.codescene-vscode-noace" : {
+            "disallowInstall": true,
+            "extension": {
+                "id": "codescene.codescene-vscode",
+                "displayName": "CodeScene"
+            }
+        },
          "HerrInformatiker.ai-rules-sync" : {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION
Deprecate `codescene.codescene-vscode-noace` in favor of `codescene.codescene-vscode`