### PR TITLE
Deprecate sf-org-summary

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -538,6 +538,9 @@
         "ForceConfigControl.lightningflowscanner": {
             "disallowInstall": true
         },
+        "sforgsummary.sf-org-summary": {
+            "disallowInstall": true
+        },
         "DrMerfy.overtype": true,
         "jroesch.lean": true,
         "moalamri.inline-fold": true,


### PR DESCRIPTION
This PR adds sforgsummary.sf-org-summary as a deprecated extension in the extension JSON, ensuring disallowing future installs from the Open VSX registry. 