### PR TITLE
add at-ishikawa.vscode-dired-mode into an extensions.json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -87,6 +87,9 @@
   "attilabuti.brainfuck-syntax": {
     "repository": "https://github.com/attilabuti/brainfuck-syntax"
   },
+  "at-ishikawa.vscode-dired-mode": {
+    "repository": "https://github.com/at-ishikawa/vscode-dired-mode"
+  },
   "aurorabiz.blade-ui-kit": {
     "repository": "https://github.com/Y-open/blade-ui-kit-vscode"
   },


### PR DESCRIPTION
<!--

### For extension authors

`publish-extensions` exists to seed the Open VSX marketplace, and also serves as a place for extensions that cannot feasibly be published directly by the extensions authors. In the long-run it is better for extension owners to publish their own plugins because:

If you are the author of the extension being raised in this PR, please first consider directly publishing the extension yourself. You can refer to our [direct publish setup](docs/direct_publish_setup.md) doc for a guide on how to publish your plugin to Open VSX.

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to Open VSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

-   [X] I have read the note above about PRs contributing or fixing extensions
-   [X] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR introduces adding an [extension](https://github.com/at-ishikawa/vscode-dired-mode) in order to download the extension on my editor.