### PR TITLE
feat: adds the `stjude-rust-labs.sprocket-vscode` extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1357,6 +1357,9 @@
   "steoates.autoimport": {
     "repository": "https://github.com/soates/Auto-Import"
   },
+  "stjude-rust-labs.sprocket-vscode": {
+    "repository": "https://github.com/stjude-rust-labs/sprocket-vscode"
+  },
   "stripe.vscode-stripe": {
     "repository": "https://github.com/stripe/vscode-stripe"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the `stjude-rust-labs.sprocket-vscode` extension.
