### PR TITLE
Add errata-ai.vale-server to deprecated extensions

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -79,6 +79,14 @@
         }
     ],
     "deprecated": {
+        
+        "errata-ai.vale-server": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "errata-ai.vale-server",
+                "displayName": "Vale"
+            }
+        },
         "HerrInformatiker.ai-rules-sync": {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION

-   [ ] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [ ] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This extension was long deprecated in favour of https://open-vsx.org/vscode/item?itemName=chrischinchilla.vale-vscode

And I keep getting issue reports about it :)