### PR TITLE
Add new dependency commands for the mypy extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -848,6 +848,8 @@
       "/usr/bin/python3 -m venv .venv",
       "source .venv/bin/activate && python -m pip install nox",
       "source .venv/bin/activate && python -m pip install -t ./bundled/libs --no-cache-dir --no-user --implementation py --no-deps --upgrade -r ./requirements.txt",
+      "git submodule update --init --recursive",
+      "source .venv/bin/activate && python -m pip install -t ./bundled/libs --no-cache-dir --no-deps --upgrade ./external/vscode-common-python-lsp/python",
       "npm ci --prefer-offline",
       "npm run vsce-package"
     ],


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This pull request aims to fix https://github.com/EclipseFdn/publish-extensions/issues/1153, as I'm also experiencing the same issue described there. The commands I added are borrowed from the `noxfile.py` file used by the vscode-isort extension: https://github.com/microsoft/vscode-isort/blob/main/noxfile.py#L102. When building and installing the extension locally with these commands, it seems to resolve the issue for me.
